### PR TITLE
Invalidate the socket before releasing.

### DIFF
--- a/SPLPing/SPLPing.m
+++ b/SPLPing/SPLPing.m
@@ -171,8 +171,13 @@ static void socketCallback(CFSocketRef s, CFSocketCallBackType type, CFDataRef a
 {
     [self stop];
 
-    CFRunLoopSourceInvalidate(_socketSource); CFRelease(_socketSource); _socketSource = nil;
-    CFRelease(_socket); _socket = nil;
+    CFRunLoopSourceInvalidate(_socketSource); 
+    CFRelease(_socketSource);
+    _socketSource = nil;
+    
+    CFSocketInvalidate(_socket);
+    CFRelease(_socket);
+    _socket = nil;
 }
 
 #pragma mark - Instance methods


### PR DESCRIPTION
The socket was not being invalidated before it was released in dealloc so if you have long running code that is creating and destroying these sockets you will consume socket descriptors.